### PR TITLE
More easy run with virtualenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ ENV/
 
 .vscode/
 debian/files
+.idea

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pycairo==1.19.1
+PyGObject==3.36.0
+PyGObject-stubs==0.0.2


### PR DESCRIPTION
Added to gitignore files for PyCharm
Added requirements.txt. I need install PyObject following this tutorial https://pygobject.readthedocs.io/en/latest/devguide/dev_environ.html

I don't know if is need to complete the README with new dependencies